### PR TITLE
chore(ci): enforce no gemini 2.5 in factory workflows

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -64,3 +64,40 @@ jobs:
             }
           done
           echo "PR evidence contract validated."
+
+  validate_model_policy:
+    if: github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), 'factory')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enforce model policy (block gemini-2.5)
+        run: |
+          mapfile -t candidates < <(
+            while IFS= read -r file; do
+              if jq -e '.graph.nodes' "$file" >/dev/null 2>&1; then
+                echo "$file"
+              fi
+            done < <(find . -type f -name "*.json")
+          )
+
+          if [ "${#candidates[@]}" -eq 0 ]; then
+            echo "No workflow draft JSON files found in repo. Skipping model-policy file checks."
+            exit 0
+          fi
+
+          failed=0
+          for file in "${candidates[@]}"; do
+            echo "Checking workflow draft file: $file"
+            if ! scripts/factory/validate_no_gemini25_in_draft.sh --draft-file "$file"; then
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "Model policy validation failed."
+            exit 1
+          fi
+
+          echo "Model policy validation passed."

--- a/scripts/factory/validate_no_gemini25_in_draft.sh
+++ b/scripts/factory/validate_no_gemini25_in_draft.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  validate_no_gemini25_in_draft.sh --draft-file <path>
+  validate_no_gemini25_in_draft.sh --app-id <uuid> [--base-url <url>] [--cookie-file <path>]
+
+Examples:
+  scripts/factory/validate_no_gemini25_in_draft.sh --draft-file /tmp/draft.json
+  scripts/factory/validate_no_gemini25_in_draft.sh --app-id 30c441d5-0232-4329-9f58-5685dd5f304c --cookie-file /tmp/dify_console_cookie.txt
+USAGE
+}
+
+BASE_URL="http://127.0.0.1:18080/console/api"
+COOKIE_FILE="/tmp/dify_console_cookie.txt"
+DRAFT_FILE=""
+APP_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --draft-file)
+      DRAFT_FILE="${2:-}"
+      shift 2
+      ;;
+    --app-id)
+      APP_ID="${2:-}"
+      shift 2
+      ;;
+    --base-url)
+      BASE_URL="${2:-}"
+      shift 2
+      ;;
+    --cookie-file)
+      COOKIE_FILE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$DRAFT_FILE" && -z "$APP_ID" ]]; then
+  echo "You must provide --draft-file or --app-id" >&2
+  usage
+  exit 2
+fi
+
+TMP_JSON=""
+if [[ -n "$APP_ID" ]]; then
+  TMP_JSON="$(mktemp)"
+  curl -fsS -X GET "${BASE_URL}/apps/${APP_ID}/workflows/draft" -b "$COOKIE_FILE" > "$TMP_JSON"
+  DRAFT_FILE="$TMP_JSON"
+fi
+
+if [[ ! -f "$DRAFT_FILE" ]]; then
+  echo "Draft file not found: $DRAFT_FILE" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 2
+fi
+
+BLOCKED="$(jq -r '
+  .graph.nodes[]
+  | select(.data.type=="llm")
+  | {id: .id, title: .data.title, provider: .data.model.provider, model: .data.model.name}
+  | select(.model | test("^gemini-2\\.5"))
+  | @json
+' "$DRAFT_FILE")"
+
+if [[ -n "$BLOCKED" ]]; then
+  echo "FAIL: blocked model family detected (gemini-2.5-*)" >&2
+  echo "$BLOCKED" >&2
+  exit 1
+fi
+
+echo "PASS: no gemini-2.5-* model configured in LLM nodes."
+jq -r '
+  .graph.nodes[]
+  | select(.data.type=="llm")
+  | [.id, .data.title, .data.model.provider, .data.model.name]
+  | @tsv
+' "$DRAFT_FILE"
+


### PR DESCRIPTION
## Changes
- Adiciona gate de política de modelo no workflow `factory-validation` para bloquear `gemini-2.5-*`.
- Inclui script `scripts/factory/validate_no_gemini25_in_draft.sh` para validar drafts de workflow.
- Mantém comportamento tolerante quando não houver JSON de draft no repositório (skip explícito).

## Tests
- [x] Execução local do script em draft com `gemini-3.1-pro-preview` (PASS).
- [x] Execução local do script em draft mutado com `gemini-2.5-pro` (FAIL esperado).
- [x] Validação de sintaxe do workflow revisada no diff.
- **Comandos executados:**
  - `scripts/factory/validate_no_gemini25_in_draft.sh --draft-file /tmp/dify_pilot1_draft_after_provider_swap.json`
  - `scripts/factory/validate_no_gemini25_in_draft.sh --draft-file /tmp/dify_pilot1_draft_block_test.json`

## Acceptance Criteria
- [x] PR com label `factory` executa `factory-validation`.
- [x] Regressão para `gemini-2.5-*` passa a ser bloqueada no CI.
- [x] Estado atual com `gemini-3.1-pro-preview` continua permitido.

## Risks
- **Nível de Risco:** Baixo
- **Áreas Afetadas:** Gate de validação do workflow `factory-validation`.
- **Mitigação/Rollback:** Reverter este PR restaura comportamento anterior imediatamente.

## Evidence
- Logs locais de teste do gate (PASS/FAIL esperado) registrados no runbook.
- Arquivos alterados:
  - `.github/workflows/factory-validation.yml`
  - `scripts/factory/validate_no_gemini25_in_draft.sh`
