### PR TITLE
feat(api): add /health/details with uptime and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # factory-workflow-eval
 
-Pilot repository for Dify software factory workflow validation.
+Pilot repo for Dify software factory workflow validation
 
-Validation marker: 2026-02-24T21:08:16Z
+Validation marker: 2026-02-24T21:08:14Z
 
 ## Health Endpoint (Pilot)
 
@@ -12,10 +12,11 @@ Run server:
 python3 app/health_server.py
 ```
 
-Smoke test:
+Smoke tests:
 
 ```bash
 curl -sS http://127.0.0.1:8000/health
+curl -sS http://127.0.0.1:8000/health/details
 ```
 
 Run tests:

--- a/app/health_server.py
+++ b/app/health_server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Minimal HTTP server exposing GET /health for pilot validation."""
+"""Minimal HTTP server exposing health endpoints for pilot validation."""
 
 from __future__ import annotations
 
@@ -7,23 +7,45 @@ import json
 import os
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from time import monotonic
+
+START_MONOTONIC = monotonic()
+APP_VERSION = os.getenv("APP_VERSION", "0.1.0")
+
+
+def now_utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 class HealthHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802
-        if self.path != "/health":
-            self.send_response(404)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"error": "not_found"}).encode("utf-8"))
+        if self.path == "/health":
+            self._write_json(
+                200,
+                {
+                    "status": "ok",
+                    "timestamp": now_utc_iso(),
+                },
+            )
             return
 
-        payload = {
-            "status": "ok",
-            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        }
+        if self.path == "/health/details":
+            self._write_json(
+                200,
+                {
+                    "status": "ok",
+                    "timestamp": now_utc_iso(),
+                    "uptime_seconds": round(max(monotonic() - START_MONOTONIC, 0.0), 3),
+                    "version": APP_VERSION,
+                },
+            )
+            return
+
+        self._write_json(404, {"error": "not_found"})
+
+    def _write_json(self, status: int, payload: dict[str, object]) -> None:
         body = json.dumps(payload).encode("utf-8")
-        self.send_response(200)
+        self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()

--- a/tests/test_health_server.py
+++ b/tests/test_health_server.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 import unittest
 from datetime import datetime
 from http.client import HTTPConnection
 from http.server import HTTPServer
 
-from app.health_server import HealthHandler
+from app.health_server import APP_VERSION, HealthHandler
 
 
 class HealthServerTest(unittest.TestCase):
@@ -24,28 +25,33 @@ class HealthServerTest(unittest.TestCase):
         cls.server.server_close()
         cls.thread.join(timeout=1)
 
-    def test_health_success(self) -> None:
+    def request_json(self, path: str):
         conn = HTTPConnection("127.0.0.1", self.port, timeout=5)
-        conn.request("GET", "/health")
+        conn.request("GET", path)
         res = conn.getresponse()
         body = res.read().decode("utf-8")
         conn.close()
+        return res, json.loads(body)
 
+    def test_health_success(self) -> None:
+        res, payload = self.request_json("/health")
         self.assertEqual(res.status, 200)
         self.assertEqual(res.getheader("Content-Type"), "application/json")
-        payload = json.loads(body)
         self.assertEqual(payload["status"], "ok")
         datetime.fromisoformat(payload["timestamp"].replace("Z", "+00:00"))
 
-    def test_unknown_route(self) -> None:
-        conn = HTTPConnection("127.0.0.1", self.port, timeout=5)
-        conn.request("GET", "/unknown")
-        res = conn.getresponse()
-        body = res.read().decode("utf-8")
-        conn.close()
+    def test_health_details_success(self) -> None:
+        res, payload = self.request_json("/health/details")
+        self.assertEqual(res.status, 200)
+        self.assertEqual(payload["status"], "ok")
+        datetime.fromisoformat(payload["timestamp"].replace("Z", "+00:00"))
+        self.assertIsInstance(payload["uptime_seconds"], (int, float))
+        self.assertGreaterEqual(payload["uptime_seconds"], 0)
+        self.assertEqual(payload["version"], APP_VERSION)
 
+    def test_unknown_route(self) -> None:
+        res, payload = self.request_json("/unknown")
         self.assertEqual(res.status, 404)
-        payload = json.loads(body)
         self.assertEqual(payload["error"], "not_found")
 
 


### PR DESCRIPTION
## Changes
- Expande servidor para suportar `GET /health/details`.
- Mantém compatibilidade do `GET /health` (status + timestamp UTC).
- Adiciona `uptime_seconds` (>= 0) e `version` (env `APP_VERSION`, default `0.1.0`) no endpoint de detalhes.
- Ajusta README com exemplos curl para os dois endpoints.

## Tests
- [x] `python3 -m unittest discover -s tests -v`
- [x] `curl -sS http://127.0.0.1:8000/health`
- [x] `curl -sS http://127.0.0.1:8000/health/details`

Resultados:
- `Ran 3 tests ... OK`
- `/health` -> JSON com `status` e `timestamp`
- `/health/details` -> JSON com `status`, `timestamp`, `uptime_seconds`, `version`

## Acceptance Criteria
- [x] `GET /health` retorna `HTTP 200` com `status` e `timestamp` UTC.
- [x] `GET /health/details` retorna `HTTP 200` com `status`, `timestamp`, `uptime_seconds`, `version`.
- [x] `uptime_seconds` é numérico e `>= 0`.
- [x] Endpoints sem autenticação.

## Risks
- Baixo risco: alteração isolada no servidor de health.
- Mitigação: testes cobrindo rota legada e nova rota.

## Evidence
- Issue: `#6`
- Diff por arquivo:
  - `app/health_server.py`
  - `tests/test_health_server.py`
  - `README.md`
- Evidências locais:
  - `/tmp/factory_health2_unittest.txt`
  - `/tmp/factory_health2_curl_health.json`
  - `/tmp/factory_health2_curl_details.json`

Closes #6
