### PR TITLE
feat(api): add /health/ready endpoint with dependency status

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Smoke tests:
 ```bash
 curl -sS http://127.0.0.1:8000/health
 curl -sS http://127.0.0.1:8000/health/details
+curl -sS http://127.0.0.1:8000/health/ready
+```
+
+Not-ready simulation:
+
+```bash
+READY_DB=false curl -sS http://127.0.0.1:8000/health/ready
 ```
 
 Run tests:

--- a/tests/test_health_server.py
+++ b/tests/test_health_server.py
@@ -25,6 +25,20 @@ class HealthServerTest(unittest.TestCase):
         cls.server.server_close()
         cls.thread.join(timeout=1)
 
+    def setUp(self) -> None:
+        self._saved_env = {
+            "READY_DB": os.environ.get("READY_DB"),
+            "READY_CACHE": os.environ.get("READY_CACHE"),
+            "READY_QUEUE": os.environ.get("READY_QUEUE"),
+        }
+
+    def tearDown(self) -> None:
+        for key, value in self._saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
     def request_json(self, path: str):
         conn = HTTPConnection("127.0.0.1", self.port, timeout=5)
         conn.request("GET", path)
@@ -48,6 +62,26 @@ class HealthServerTest(unittest.TestCase):
         self.assertIsInstance(payload["uptime_seconds"], (int, float))
         self.assertGreaterEqual(payload["uptime_seconds"], 0)
         self.assertEqual(payload["version"], APP_VERSION)
+
+    def test_health_ready_success(self) -> None:
+        os.environ["READY_DB"] = "true"
+        os.environ["READY_CACHE"] = "true"
+        os.environ["READY_QUEUE"] = "true"
+        res, payload = self.request_json("/health/ready")
+        self.assertEqual(res.status, 200)
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(payload["dependencies"], {"db": True, "cache": True, "queue": True})
+        datetime.fromisoformat(payload["timestamp"].replace("Z", "+00:00"))
+
+    def test_health_ready_not_ready(self) -> None:
+        os.environ["READY_DB"] = "false"
+        os.environ["READY_CACHE"] = "true"
+        os.environ["READY_QUEUE"] = "true"
+        res, payload = self.request_json("/health/ready")
+        self.assertEqual(res.status, 503)
+        self.assertEqual(payload["status"], "not_ready")
+        self.assertEqual(payload["dependencies"], {"db": False, "cache": True, "queue": True})
+        datetime.fromisoformat(payload["timestamp"].replace("Z", "+00:00"))
 
     def test_unknown_route(self) -> None:
         res, payload = self.request_json("/unknown")


### PR DESCRIPTION
## Changes
- Adiciona endpoint `GET /health/ready` com semântica de prontidão.
- Endpoint calcula readiness por env vars:
  - `READY_DB` (default `true`)
  - `READY_CACHE` (default `true`)
  - `READY_QUEUE` (default `true`)
- Retorna:
  - `HTTP 200` + `status=ready` quando todas dependências estão prontas.
  - `HTTP 503` + `status=not_ready` quando qualquer dependência está indisponível.
- Mantém endpoints existentes `/health` e `/health/details`.
- Atualiza `README.md` com curls de `ready` e simulação `not_ready`.

## Tests
- [x] `python3 -m unittest discover -s tests -v`
- [x] `curl -sS http://127.0.0.1:8000/health`
- [x] `curl -sS http://127.0.0.1:8000/health/details`
- [x] `curl -sS -i http://127.0.0.1:8001/health/ready` com servidor iniciado em `READY_DB=false`

Resultados:
- `Ran 5 tests ... OK`
- `/health` retorna 200 com `status` + `timestamp`
- `/health/details` retorna 200 com `status` + `timestamp` + `uptime_seconds` + `version`
- `/health/ready` com `READY_DB=false` retorna `HTTP/1.0 503 Service Unavailable` + `status=not_ready`

## Acceptance Criteria
- [x] `GET /health/ready` retorna 200 quando dependências prontas.
- [x] `GET /health/ready` retorna 503 quando alguma dependência indisponível.
- [x] Resposta contém `status`, `timestamp`, `dependencies` (`db`, `cache`, `queue`).
- [x] Endpoints sem autenticação.

## Risks
- Risco baixo: mudança localizada em endpoint de health.
- Mitigação: cobertura de testes para cenários ready/not_ready + compatibilidade de endpoints existentes.

## Evidence
- Issue: `#8`
- Diff por arquivo:
  - `app/health_server.py`
  - `tests/test_health_server.py`
  - `README.md`
- Evidências locais:
  - `/tmp/factory_health3_unittest.txt`
  - `/tmp/factory_health3_curl_health.json`
  - `/tmp/factory_health3_curl_details.json`
  - `/tmp/factory_health3_curl_ready_503_http.txt`

Closes #8
