### PR TITLE
ci: add quality and security baseline gate

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -101,3 +101,21 @@ jobs:
           fi
 
           echo "Model policy validation passed."
+
+  validate_quality_security:
+    if: github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), 'factory')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run quality and security baseline checks
+        run: |
+          chmod +x scripts/quality/run_quality_security_checks.sh
+          chmod +x scripts/quality/scan_for_secrets.sh
+          scripts/quality/run_quality_security_checks.sh

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Run tests:
 python3 -m unittest discover -s tests -v
 ```
 
+Run quality/security baseline (local, same as CI gate):
+
+```bash
+scripts/quality/run_quality_security_checks.sh
+```
+
 Policy validation marker: 2026-02-24T22:59:33Z
 
 Auto-merge validation marker: 2026-02-24T23:06:04Z

--- a/scripts/quality/run_quality_security_checks.sh
+++ b/scripts/quality/run_quality_security_checks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[quality] Python syntax check"
+python3 -m py_compile app/*.py tests/*.py scripts/*.py
+
+echo "[quality] Unit tests"
+python3 -m unittest discover -s tests -v
+
+echo "[security] Static secrets scan"
+bash scripts/quality/scan_for_secrets.sh
+
+echo "[quality-security] all checks passed"

--- a/scripts/quality/scan_for_secrets.sh
+++ b/scripts/quality/scan_for_secrets.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[security] scanning tracked files for potential plaintext secrets"
+
+tmp_matches="$(mktemp)"
+trap 'rm -f "$tmp_matches"' EXIT
+
+git ls-files | while IFS= read -r file; do
+  case "$file" in
+    *.png|*.jpg|*.jpeg|*.gif|*.svg|*.ico|*.pdf|*.lock|*.db) continue ;;
+  esac
+  rg -n --no-heading \
+    -e 'sk-[A-Za-z0-9_-]{20,}' \
+    -e 'AIza[0-9A-Za-z\\-_]{35}' \
+    -e 'OPENAI_API_KEY\\s*=\\s*.+$' \
+    -e 'GEMINI_API_KEY\\s*=\\s*.+$' \
+    "$file" >>"$tmp_matches" || true
+done
+
+if [ -s "$tmp_matches" ]; then
+  echo "[security] potential secrets detected:"
+  cat "$tmp_matches"
+  exit 1
+fi
+
+echo "[security] no potential plaintext secrets found"


### PR DESCRIPTION
## Changes
- Added reusable local/CI baseline gate script: `scripts/quality/run_quality_security_checks.sh`.
- Added plaintext secret detection script: `scripts/quality/scan_for_secrets.sh`.
- Extended `.github/workflows/factory-validation.yml` with `validate_quality_security` job for factory PRs.
- Updated README with local quality/security execution command.

## Tests
- `scripts/quality/run_quality_security_checks.sh`
- Includes:
  - Python syntax check (`py_compile`)
  - Unit tests (`python3 -m unittest discover -s tests -v`)
  - Secret scan (`scripts/quality/scan_for_secrets.sh`)

## Acceptance Criteria
- CI now runs one reproducible quality/security baseline script for factory PRs.
- Baseline includes syntax, tests, and plaintext secret scan.
- Existing tests still pass.
- Local execution command is documented.

## Risks
- Secret scan relies on regex patterns and may miss obfuscated values.
- Simple regex scanner can produce false positives in edge cases.

## Evidence
- Commit: `381fabd`
- Local baseline output: `[quality-security] all checks passed`
- Linked issue: `Closes #21`

Closes #21
