### PR TITLE
ci: enforce risk matrix section and coverage gate

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -55,6 +55,7 @@ jobs:
             "## Tests"
             "## Acceptance Criteria"
             "## Risks"
+            "## Risk Matrix"
             "## Evidence"
           )
           for section in "${required_sections[@]}"; do
@@ -119,3 +120,23 @@ jobs:
           chmod +x scripts/quality/run_quality_security_checks.sh
           chmod +x scripts/quality/scan_for_secrets.sh
           scripts/quality/run_quality_security_checks.sh
+
+  validate_coverage:
+    if: github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), 'factory')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install coverage dependency
+        run: python3 -m pip install --disable-pip-version-check coverage
+
+      - name: Run coverage gate
+        run: |
+          chmod +x scripts/quality/run_coverage_gate.sh
+          scripts/quality/run_coverage_gate.sh 70

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Run quality/security baseline (local, same as CI gate):
 scripts/quality/run_quality_security_checks.sh
 ```
 
+Run coverage gate (local, same threshold as CI):
+
+```bash
+python3 -m pip install coverage
+scripts/quality/run_coverage_gate.sh 70
+```
+
 Policy validation marker: 2026-02-24T22:59:33Z
 
 Auto-merge validation marker: 2026-02-24T23:06:04Z

--- a/scripts/quality/run_coverage_gate.sh
+++ b/scripts/quality/run_coverage_gate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+threshold="${1:-75}"
+
+echo "[coverage] running unit tests with coverage threshold ${threshold}%"
+python3 -m coverage run --source=app -m unittest discover -s tests -v
+python3 -m coverage report --fail-under "${threshold}"
+echo "[coverage] gate passed"


### PR DESCRIPTION
## Changes
- Updated PR contract validation to require `## Risk Matrix` section in factory PR bodies.
- Added coverage gate script `scripts/quality/run_coverage_gate.sh`.
- Added CI job `validate_coverage` to enforce minimum app coverage (`70%`).
- Updated README with local coverage gate command.

## Tests
- Local coverage gate:
  - `python3 -m venv .venv && source .venv/bin/activate && python -m pip install coverage && scripts/quality/run_coverage_gate.sh 70`
- Result:
  - unit tests: `Ran 11 tests ... OK`
  - app coverage: `90%`

## Acceptance Criteria
- Factory PR contract fails when `## Risk Matrix` section is missing.
- CI enforces minimum test coverage through dedicated job.
- Local command exists to run the same coverage gate.
- Existing quality/security and model-policy checks remain intact.

## Risks
- Coverage gate depends on `coverage` package availability in CI.
- Threshold tuning may need adjustments as codebase grows.

## Risk Matrix
| Risk | Probability | Impact | Mitigation |
|---|---|---|---|
| Coverage threshold causes false failures on future refactors | Medium | Medium | Reassess threshold per pilot phase with historical data |
| Coverage tool installation instability | Low | Medium | Keep install step explicit and fail fast with clear logs |
| Contract strictness increases PR friction | Medium | Low | Document template and examples in runbook |

## Evidence
- Commit: `b394fa4`
- New CI run includes `validate_coverage` job.
- Linked issue: `Closes #23`

Closes #23
