### PR TITLE
ci: require execution evidence section in factory PR body

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -56,6 +56,7 @@ jobs:
             "## Acceptance Criteria"
             "## Risks"
             "## Risk Matrix"
+            "## Execution Evidence"
             "## Evidence"
           )
           for section in "${required_sections[@]}"; do
@@ -64,6 +65,23 @@ jobs:
               exit 1
             }
           done
+
+          execution_block="$(echo "$PR_BODY" | awk '
+            /^## Execution Evidence/ {capture=1; next}
+            /^## / && capture==1 {exit}
+            capture==1 {print}
+          ')"
+
+          echo "$execution_block" | grep -Eq '^- Command: .+' || {
+            echo "Execution evidence must include at least one '- Command: ...' line."
+            exit 1
+          }
+
+          echo "$execution_block" | grep -Eq '^- Result: .+' || {
+            echo "Execution evidence must include at least one '- Result: ...' line."
+            exit 1
+          }
+
           echo "PR evidence contract validated."
 
   validate_model_policy:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ python3 -m pip install coverage
 scripts/quality/run_coverage_gate.sh 70
 ```
 
+PR body evidence template (required for factory PRs):
+
+```md
+## Execution Evidence
+- Command: `scripts/quality/run_quality_security_checks.sh`
+- Result: `PASS (all checks passed)`
+- Command: `scripts/quality/run_coverage_gate.sh 70`
+- Result: `PASS (TOTAL >= 70%)`
+```
+
 Policy validation marker: 2026-02-24T22:59:33Z
 
 Auto-merge validation marker: 2026-02-24T23:06:04Z


### PR DESCRIPTION
## Changes
- Extended PR contract validator to require `## Execution Evidence` section.
- Added format checks to enforce at least one `- Command:` and one `- Result:` line in execution evidence.
- Updated README with execution evidence template for factory PRs.

## Tests
- `scripts/quality/run_quality_security_checks.sh`
- `scripts/quality/run_coverage_gate.sh 70` (executed in local venv with coverage installed)
- Results: unit tests passing (`Ran 11 tests ... OK`), coverage gate passing (`TOTAL 90%`).

## Acceptance Criteria
- PR contract fails when `## Execution Evidence` is missing.
- PR contract fails when `## Execution Evidence` does not include command/result entries.
- README documents expected execution evidence format.
- Existing PR checks continue passing.

## Risks
- Strict formatting may initially fail PRs that have valid evidence but different wording.
- Parsing relies on markdown heading conventions (`##`) for section boundaries.

## Risk Matrix
| Risk | Probability | Impact | Mitigation |
|---|---|---|---|
| Formatting friction for contributors | Medium | Low | Provide README template and copy-ready example |
| False negatives if heading style diverges | Low | Medium | Keep contract examples explicit and consistent |
| Increased PR checklist burden | Medium | Low | Keep command/result lines short and objective |

## Execution Evidence
- Command: `scripts/quality/run_quality_security_checks.sh`
- Result: `PASS ([quality-security] all checks passed)`
- Command: `python3 -m venv .venv && source .venv/bin/activate && python -m pip install coverage && scripts/quality/run_coverage_gate.sh 70`
- Result: `PASS (TOTAL 90%)`

## Evidence
- Commit: `257570f`
- Issue linked: `Closes #25`
- Expected CI checks: `validate_pr_contract`, `validate_model_policy`, `validate_quality_security`, `validate_coverage`

Closes #25
