### PR TITLE
ci: enforce evidence schema version in PR contract

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -126,6 +126,18 @@ jobs:
             exit 1
           }
 
+          schema_version_line="$(echo "$records_block" | grep -E '^- EVIDENCE_SCHEMA_VERSION:\s*.+$' || true)"
+          if [ -z "$schema_version_line" ]; then
+            echo "Evidence Records must include '- EVIDENCE_SCHEMA_VERSION: v1'."
+            exit 1
+          fi
+
+          schema_version="$(echo "$schema_version_line" | sed -E 's/^- EVIDENCE_SCHEMA_VERSION:\s*//')"
+          if [ "$schema_version" != "v1" ]; then
+            echo "Unsupported EVIDENCE_SCHEMA_VERSION: '$schema_version'. Expected 'v1'."
+            exit 1
+          fi
+
           echo "PR evidence contract validated."
 
   validate_model_policy:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ PR evidence records template (required for factory PRs):
 
 ```md
 ## Evidence Records
+- EVIDENCE_SCHEMA_VERSION: v1
 - EVIDENCE_COMMAND_1: scripts/quality/run_quality_security_checks.sh
 - EVIDENCE_RESULT_1: PASS
 - EVIDENCE_ARTIFACT_1: local-terminal-output


### PR DESCRIPTION
## Changes
- Added mandatory evidence schema key to parseable evidence records contract.
- Validator now requires `- EVIDENCE_SCHEMA_VERSION: v1` under `## Evidence Records`.
- Validator now fails on missing or unsupported schema version.
- Updated README template to include schema version line.

## Tests
- Command: `scripts/quality/run_quality_security_checks.sh`
- Result: `PASS`
- Command: `python3 -m venv .venv && source .venv/bin/activate && python -m pip install coverage && scripts/quality/run_coverage_gate.sh 70`
- Result: `PASS (TOTAL 90%)`

## Acceptance Criteria
- `EVIDENCE_SCHEMA_VERSION` key is required in `## Evidence Records`.
- Only `v1` is accepted by current validator.
- README reflects schema version requirement.
- Existing gates remain green.

## Risks
- Hardcoded version validation requires coordinated update when schema evolves.
- Contributors may forget schema field until template adoption stabilizes.

## Risk Matrix
| Risk | Probability | Impact | Mitigation |
|---|---|---|---|
| Schema upgrade causes sudden contract failures | Medium | Medium | Plan migration with dual-accept window in future pilot |
| Missing schema key in manual PR bodies | Medium | Low | Keep README snippet copy-ready |
| Version drift between docs and validator | Low | Medium | Update validator and template in same PR |

## Traceability
- Issue URL: https://github.com/reinaldosaraiva/factory-workflow-eval/issues/31
- PR URL: https://github.com/reinaldosaraiva/factory-workflow-eval/pull/32
- Run URL: https://github.com/reinaldosaraiva/factory-workflow-eval/actions/runs/22377295026

## Execution Evidence
- Command: `scripts/quality/run_quality_security_checks.sh`
- Result: `PASS`
- Command: `scripts/quality/run_coverage_gate.sh 70`
- Result: `PASS (TOTAL 90%)`

## Evidence Records
- EVIDENCE_SCHEMA_VERSION: v1
- EVIDENCE_COMMAND_1: scripts/quality/run_quality_security_checks.sh
- EVIDENCE_RESULT_1: PASS
- EVIDENCE_ARTIFACT_1: local-terminal-output-quality-security

## Evidence
- Commit: `6069d68`
- Linked issue: `Closes #31`

Closes #31
