### PR TITLE
ci: validar consistência cruzada entre resultado e artefato

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -165,6 +165,9 @@ jobs:
               exit 1
             }
 
+            artifact_value="$(
+              echo "$records_block" | sed -nE "s/^- EVIDENCE_ARTIFACT_${idx}:\\s*(.+)$/\\1/p" | head -n 1
+            )"
             result_value="$(
               echo "$records_block" | sed -nE "s/^- EVIDENCE_RESULT_${idx}:\\s*(.+)$/\\1/p" | head -n 1
             )"
@@ -172,6 +175,13 @@ jobs:
               echo "Evidence Records EVIDENCE_RESULT_${idx} must use status PASS|FAIL|WARN|SKIP, optionally with details in parentheses."
               exit 1
             }
+
+            if echo "$result_value" | grep -Eq '^(FAIL|WARN)(\s*\(.+\))?$'; then
+              echo "$artifact_value" | grep -Eqi '^(local-terminal-output|none|n/a|na)$' && {
+                echo "Evidence Records EVIDENCE_ARTIFACT_${idx} must be a concrete artifact when EVIDENCE_RESULT_${idx} is FAIL or WARN."
+                exit 1
+              }
+            fi
 
             expected_index=$((expected_index + 1))
           done <<< "$record_indexes"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ PR evidence records template (required for factory PRs):
 ```
 
 `EVIDENCE_RESULT_n` format: `PASS|FAIL|WARN|SKIP` with optional details in parentheses.
+If `EVIDENCE_RESULT_n` is `FAIL` or `WARN`, `EVIDENCE_ARTIFACT_n` must be a concrete artifact (not `local-terminal-output`, `none`, `n/a`, or `na`).
 
 Policy validation marker: 2026-02-24T22:59:33Z
 


### PR DESCRIPTION
## Changes
- Adds cross-check validation between `EVIDENCE_RESULT_n` and `EVIDENCE_ARTIFACT_n`.
- For `EVIDENCE_RESULT_n` in `FAIL|WARN`, artifact placeholders are now rejected.
- Rejected placeholders for risky outcomes: `local-terminal-output`, `none`, `n/a`, `na`.
- Validation is applied to every indexed record detected in `## Evidence Records`.
- README updated with explicit rule for concrete artifacts on `FAIL|WARN`.
- Closes #37.

## Tests
- `scripts/quality/run_quality_security_checks.sh`
- `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`

## Acceptance Criteria
- [x] `FAIL|WARN` now require concrete artifact value.
- [x] Known generic placeholders are blocked.
- [x] Rule applies to all indexed records.
- [x] README documents the cross-check behavior.

## Risks
- Existing PR templates using generic artifacts for WARN/FAIL will fail until adjusted.
- Placeholder list may need expansion if new generic values appear.

## Risk Matrix
- Risk: False negatives due to unlisted generic placeholders
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: Keep placeholder list versioned and extend incrementally.
- Risk: Increased contributor friction for WARN/FAIL cases
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: README now clarifies expected concrete artifact format.

## Traceability
- Issue URL: https://github.com/reinaldosaraiva/factory-workflow-eval/issues/37
- PR URL: https://github.com/reinaldosaraiva/factory-workflow-eval/pull/38
- Run URL: https://github.com/reinaldosaraiva/factory-workflow-eval/actions/runs/22396736295

## Execution Evidence
- Command: `scripts/quality/run_quality_security_checks.sh`
- Result: `PASS (all checks passed)`
- Command: `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`
- Result: `PASS (TOTAL 90% >= 70%)`

## Evidence Records
- EVIDENCE_SCHEMA_VERSION: v1
- EVIDENCE_COMMAND_1: scripts/quality/run_quality_security_checks.sh
- EVIDENCE_RESULT_1: PASS (all checks passed)
- EVIDENCE_ARTIFACT_1: local-terminal-output
- EVIDENCE_COMMAND_2: scripts/quality/run_coverage_gate.sh 70
- EVIDENCE_RESULT_2: PASS (TOTAL 90% >= 70%)
- EVIDENCE_ARTIFACT_2: coverage-report-total-90

## Evidence
- Local quality/security baseline: PASS
- Local coverage gate: PASS (`TOTAL 90%`)
- Changed files:
  - `.github/workflows/factory-validation.yml`
  - `README.md`