### PR TITLE
ci: validar formato mínimo de artifact para WARN/FAIL

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -181,6 +181,11 @@ jobs:
                 echo "Evidence Records EVIDENCE_ARTIFACT_${idx} must be a concrete artifact when EVIDENCE_RESULT_${idx} is FAIL or WARN."
                 exit 1
               }
+
+              echo "$artifact_value" | grep -Eq '^(https?://.+|[A-Za-z0-9._/-]+\.[A-Za-z0-9]{1,10})$' || {
+                echo "Evidence Records EVIDENCE_ARTIFACT_${idx} must be a URL (http/https) or a file path with extension when EVIDENCE_RESULT_${idx} is FAIL or WARN."
+                exit 1
+              }
             fi
 
             expected_index=$((expected_index + 1))

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ PR evidence records template (required for factory PRs):
 
 `EVIDENCE_RESULT_n` format: `PASS|FAIL|WARN|SKIP` with optional details in parentheses.
 If `EVIDENCE_RESULT_n` is `FAIL` or `WARN`, `EVIDENCE_ARTIFACT_n` must be a concrete artifact (not `local-terminal-output`, `none`, `n/a`, or `na`).
+For `FAIL|WARN`, use artifact as `http(s)://...` or file path with extension (for example: `reports/error-log.txt`).
 
 Policy validation marker: 2026-02-24T22:59:33Z
 


### PR DESCRIPTION
## Changes
- Adds minimum format validation for `EVIDENCE_ARTIFACT_n` when `EVIDENCE_RESULT_n` is `WARN|FAIL`.
- For risky outcomes, artifact must be either:
  - URL starting with `http://` or `https://`, or
  - file path with extension (e.g. `reports/error-log.txt`).
- Keeps previous placeholder restrictions for `WARN|FAIL`.
- Applies validation to every indexed evidence record.
- Updates README with expected artifact format for risky statuses.
- Closes #39.

## Tests
- `scripts/quality/run_quality_security_checks.sh`
- `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`

## Acceptance Criteria
- [x] `WARN|FAIL` requires URL or file path with extension.
- [x] Invalid artifact formats fail `validate_pr_contract`.
- [x] Rule applies for all record indexes.
- [x] README reflects the new rule.

## Risks
- Some valid artifact styles without extension may now fail (intentional strictness).
- Regex may need incremental refinement for edge path formats.

## Risk Matrix
- Risk: False negatives for unconventional artifact paths
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: Iterate regex with concrete examples from failures.
- Risk: Contributor friction on first adoption
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: README updated with explicit valid patterns.

## Traceability
- Issue URL: https://github.com/reinaldosaraiva/factory-workflow-eval/issues/39
- PR URL: https://github.com/reinaldosaraiva/factory-workflow-eval/pull/40
- Run URL: https://github.com/reinaldosaraiva/factory-workflow-eval/actions/runs/22398239943

## Execution Evidence
- Command: `scripts/quality/run_quality_security_checks.sh`
- Result: `PASS (all checks passed)`
- Command: `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`
- Result: `PASS (TOTAL 90% >= 70%)`

## Evidence Records
- EVIDENCE_SCHEMA_VERSION: v1
- EVIDENCE_COMMAND_1: scripts/quality/run_quality_security_checks.sh
- EVIDENCE_RESULT_1: PASS (all checks passed)
- EVIDENCE_ARTIFACT_1: local-terminal-output
- EVIDENCE_COMMAND_2: scripts/quality/run_coverage_gate.sh 70
- EVIDENCE_RESULT_2: PASS (TOTAL 90% >= 70%)
- EVIDENCE_ARTIFACT_2: coverage-report-total-90

## Evidence
- Local quality/security baseline: PASS
- Local coverage gate: PASS (`TOTAL 90%`)
- Changed files:
  - `.github/workflows/factory-validation.yml`
  - `README.md`