### PR TITLE
ci: validar unicidade em evidence records

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -191,6 +191,32 @@ jobs:
             expected_index=$((expected_index + 1))
           done <<< "$record_indexes"
 
+          duplicate_commands="$(
+            echo "$records_block" \
+              | sed -nE 's/^- EVIDENCE_COMMAND_[0-9]+:\s*(.+)$/\1/p' \
+              | sort \
+              | uniq -d
+          )"
+          [ -n "$duplicate_commands" ] && {
+            echo "Evidence Records must not contain duplicated EVIDENCE_COMMAND_n values."
+            echo "Duplicated commands:"
+            echo "$duplicate_commands"
+            exit 1
+          }
+
+          duplicate_artifacts="$(
+            echo "$records_block" \
+              | sed -nE 's/^- EVIDENCE_ARTIFACT_[0-9]+:\s*(.+)$/\1/p' \
+              | sort \
+              | uniq -d
+          )"
+          [ -n "$duplicate_artifacts" ] && {
+            echo "Evidence Records must not contain duplicated EVIDENCE_ARTIFACT_n values."
+            echo "Duplicated artifacts:"
+            echo "$duplicate_artifacts"
+            exit 1
+          }
+
           echo "PR evidence contract validated."
 
   validate_model_policy:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ PR evidence records template (required for factory PRs):
 `EVIDENCE_RESULT_n` format: `PASS|FAIL|WARN|SKIP` with optional details in parentheses.
 If `EVIDENCE_RESULT_n` is `FAIL` or `WARN`, `EVIDENCE_ARTIFACT_n` must be a concrete artifact (not `local-terminal-output`, `none`, `n/a`, or `na`).
 For `FAIL|WARN`, use artifact as `http(s)://...` or file path with extension (for example: `reports/error-log.txt`).
+Within the same PR, `EVIDENCE_COMMAND_n` and `EVIDENCE_ARTIFACT_n` values must be unique across indexes.
 
 Policy validation marker: 2026-02-24T22:59:33Z
 


### PR DESCRIPTION
## Changes
- Adds uniqueness validation for `EVIDENCE_COMMAND_n` across all indexed evidence records.
- Adds uniqueness validation for `EVIDENCE_ARTIFACT_n` across all indexed evidence records.
- Contract now fails when duplicated command/artifact values are found.
- README updated with explicit uniqueness requirement within the same PR.
- Closes #41.

## Tests
- `scripts/quality/run_quality_security_checks.sh`
- `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`

## Acceptance Criteria
- [x] Duplicate `EVIDENCE_COMMAND_n` is rejected.
- [x] Duplicate `EVIDENCE_ARTIFACT_n` is rejected.
- [x] Rule applies to all record indexes.
- [x] README documents uniqueness requirement.

## Risks
- Legitimate repeated command patterns may require more specific command annotations.
- Uniqueness rule can increase authoring friction if evidence records are not curated.

## Risk Matrix
- Risk: false rejection for intentionally repeated commands
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: require contextualized command strings per record.
- Risk: contributor friction
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: README updated with explicit guidance.

## Traceability
- Issue URL: https://github.com/reinaldosaraiva/factory-workflow-eval/issues/41
- PR URL: https://github.com/reinaldosaraiva/factory-workflow-eval/pull/42
- Run URL: https://github.com/reinaldosaraiva/factory-workflow-eval/actions/runs/22398752442

## Execution Evidence
- Command: `scripts/quality/run_quality_security_checks.sh`
- Result: `PASS (all checks passed)`
- Command: `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`
- Result: `PASS (TOTAL 90% >= 70%)`

## Evidence Records
- EVIDENCE_SCHEMA_VERSION: v1
- EVIDENCE_COMMAND_1: scripts/quality/run_quality_security_checks.sh
- EVIDENCE_RESULT_1: PASS (all checks passed)
- EVIDENCE_ARTIFACT_1: quality/run_quality_security_checks.log
- EVIDENCE_COMMAND_2: scripts/quality/run_coverage_gate.sh 70
- EVIDENCE_RESULT_2: PASS (TOTAL 90% >= 70%)
- EVIDENCE_ARTIFACT_2: coverage/summary-total-90.txt

## Evidence
- Local quality/security baseline: PASS
- Local coverage gate: PASS (`TOTAL 90%`)
- Changed files:
  - `.github/workflows/factory-validation.yml`
  - `README.md`