### PR TITLE
ci: executar agentes backend/frontend/qa via Agent Plan

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -315,3 +315,132 @@ jobs:
         run: |
           chmod +x scripts/quality/run_coverage_gate.sh
           scripts/quality/run_coverage_gate.sh 70
+
+  agent_backend:
+    if: github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), 'factory')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Execute backend agent
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          agent_plan_block="$(echo "$PR_BODY" | awk '
+            /^## Agent Plan/ {capture=1; next}
+            /^## / && capture==1 {exit}
+            capture==1 {print}
+          ')"
+
+          backend_status="$(echo "$agent_plan_block" | sed -nE 's/^- AGENT_BACKEND_STATUS:\s*(PLANNED|N\/A|DONE)$/\1/p' | head -n 1)"
+          [ -z "$backend_status" ] && {
+            echo "AGENT_BACKEND_STATUS not found in Agent Plan."
+            exit 1
+          }
+
+          echo "Backend agent status: $backend_status"
+          if [ "$backend_status" = "N/A" ]; then
+            echo "Backend agent skipped by plan."
+            exit 0
+          fi
+
+          chmod +x scripts/quality/run_quality_security_checks.sh scripts/quality/scan_for_secrets.sh
+          scripts/quality/run_quality_security_checks.sh
+          echo "Backend agent execution completed."
+
+  agent_frontend:
+    if: github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), 'factory')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Execute frontend agent
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          agent_plan_block="$(echo "$PR_BODY" | awk '
+            /^## Agent Plan/ {capture=1; next}
+            /^## / && capture==1 {exit}
+            capture==1 {print}
+          ')"
+
+          frontend_status="$(echo "$agent_plan_block" | sed -nE 's/^- AGENT_FRONTEND_STATUS:\s*(PLANNED|N\/A|DONE)$/\1/p' | head -n 1)"
+          [ -z "$frontend_status" ] && {
+            echo "AGENT_FRONTEND_STATUS not found in Agent Plan."
+            exit 1
+          }
+
+          echo "Frontend agent status: $frontend_status"
+          if [ "$frontend_status" = "N/A" ]; then
+            echo "Frontend agent skipped by plan."
+            exit 0
+          fi
+
+          # Pilot repository has no frontend source tree; keep an explicit execution marker.
+          if [ -d web ]; then
+            echo "Frontend source detected."
+          else
+            echo "Frontend source not present in pilot repository; running frontend agent in pilot mode."
+          fi
+          echo "Frontend agent execution completed."
+
+  agent_qa:
+    if: github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), 'factory')
+    runs-on: ubuntu-latest
+    needs:
+      - validate_pr_contract
+      - validate_model_policy
+      - validate_quality_security
+      - validate_coverage
+      - agent_backend
+      - agent_frontend
+    steps:
+      - name: Execute QA agent
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BACKEND_RESULT: ${{ needs.agent_backend.result }}
+          FRONTEND_RESULT: ${{ needs.agent_frontend.result }}
+          CONTRACT_RESULT: ${{ needs.validate_pr_contract.result }}
+          POLICY_RESULT: ${{ needs.validate_model_policy.result }}
+          QUALITY_RESULT: ${{ needs.validate_quality_security.result }}
+          COVERAGE_RESULT: ${{ needs.validate_coverage.result }}
+        run: |
+          agent_plan_block="$(echo "$PR_BODY" | awk '
+            /^## Agent Plan/ {capture=1; next}
+            /^## / && capture==1 {exit}
+            capture==1 {print}
+          ')"
+
+          qa_status="$(echo "$agent_plan_block" | sed -nE 's/^- AGENT_QA_STATUS:\s*(PLANNED|N\/A|DONE)$/\1/p' | head -n 1)"
+          [ -z "$qa_status" ] && {
+            echo "AGENT_QA_STATUS not found in Agent Plan."
+            exit 1
+          }
+
+          echo "QA agent status: $qa_status"
+          if [ "$qa_status" = "N/A" ]; then
+            echo "QA agent skipped by plan."
+            exit 0
+          fi
+
+          for result in \
+            "$BACKEND_RESULT" \
+            "$FRONTEND_RESULT" \
+            "$CONTRACT_RESULT" \
+            "$POLICY_RESULT" \
+            "$QUALITY_RESULT" \
+            "$COVERAGE_RESULT"; do
+            if [ "$result" != "success" ]; then
+              echo "QA gate failed: prerequisite job result is '$result'."
+              exit 1
+            fi
+          done
+
+          echo "QA agent execution completed. All prerequisite gates are successful."

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ PR agent plan template (required for factory PRs):
 - AGENT_QA_STATUS: PLANNED
 ```
 
+When `factory` PR checks run, these values drive the execution of CI jobs: `agent_backend`, `agent_frontend`, and `agent_qa`.
+
 PR evidence records template (required for factory PRs):
 
 ```md


### PR DESCRIPTION
## Changes
- Adds executable CI agent jobs: `agent_backend`, `agent_frontend`, and `agent_qa`.
- Agent jobs now read statuses from `## Agent Plan` in PR body.
- `agent_backend` runs backend baseline checks when status is not `N/A`.
- `agent_frontend` runs a pilot-mode frontend execution marker when status is not `N/A`.
- `agent_qa` consolidates prerequisite gate results and fails when any required result is non-success.
- README updated to document that Agent Plan drives these jobs.
- Closes #45.

## Tests
- `scripts/quality/run_quality_security_checks.sh`
- `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`

## Acceptance Criteria
- [x] `agent_backend` job exists and executes by plan.
- [x] `agent_frontend` job exists and executes/skips by plan.
- [x] `agent_qa` job consolidates prerequisite results.
- [x] README documents plan-driven job execution.

## Risks
- Additional jobs increase total CI runtime.
- Agent status misuse could cause unexpected skip paths.

## Risk Matrix
- Risk: CI duration growth
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: keep frontend agent lightweight in pilot mode.
- Risk: incorrect status selection in Agent Plan
  - Impact: Medium
  - Likelihood: Low
  - Mitigation: explicit contract validation and status domain checks.

## Traceability
- Issue URL: https://github.com/reinaldosaraiva/factory-workflow-eval/issues/45
- PR URL: https://github.com/reinaldosaraiva/factory-workflow-eval/pull/46
- Run URL: https://github.com/reinaldosaraiva/factory-workflow-eval/actions/runs/22408023263

## Agent Plan
- AGENT_BACKEND_STATUS: PLANNED
- AGENT_FRONTEND_STATUS: N/A
- AGENT_QA_STATUS: PLANNED

## Execution Evidence
- Command: `scripts/quality/run_quality_security_checks.sh`
- Result: `PASS (all checks passed)`
- Command: `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`
- Result: `PASS (TOTAL 90% >= 70%)`

## Evidence Records
- EVIDENCE_SCHEMA_VERSION: v1
- EVIDENCE_COMMAND_1: scripts/quality/run_quality_security_checks.sh
- EVIDENCE_RESULT_1: PASS (all checks passed)
- EVIDENCE_ARTIFACT_1: quality/run_quality_security_checks.log
- EVIDENCE_COMMAND_2: scripts/quality/run_coverage_gate.sh 70
- EVIDENCE_RESULT_2: PASS (TOTAL 90% >= 70%)
- EVIDENCE_ARTIFACT_2: coverage/summary-total-90.txt

## Evidence
- Local quality/security baseline: PASS
- Local coverage gate: PASS (`TOTAL 90%`)
- Changed files:
  - `.github/workflows/factory-validation.yml`
  - `README.md`