### PR TITLE
ci: exigir justificativa quando status de agente for N/A

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -127,6 +127,46 @@ jobs:
             exit 1
           }
 
+          backend_status="$(echo "$agent_plan_block" | sed -nE 's/^- AGENT_BACKEND_STATUS:\s*(PLANNED|N\/A|DONE)$/\1/p' | head -n 1)"
+          frontend_status="$(echo "$agent_plan_block" | sed -nE 's/^- AGENT_FRONTEND_STATUS:\s*(PLANNED|N\/A|DONE)$/\1/p' | head -n 1)"
+          qa_status="$(echo "$agent_plan_block" | sed -nE 's/^- AGENT_QA_STATUS:\s*(PLANNED|N\/A|DONE)$/\1/p' | head -n 1)"
+
+          if [ "$backend_status" = "N/A" ]; then
+            backend_justification="$(echo "$agent_plan_block" | sed -nE 's/^- AGENT_BACKEND_JUSTIFICATION:\s*(.+)$/\1/p' | head -n 1)"
+            [ -z "$backend_justification" ] && {
+              echo "Agent Plan requires AGENT_BACKEND_JUSTIFICATION when AGENT_BACKEND_STATUS is N/A."
+              exit 1
+            }
+            echo "$backend_justification" | grep -Eqi '^(n/a|na|none|-)$' && {
+              echo "AGENT_BACKEND_JUSTIFICATION cannot be a placeholder value."
+              exit 1
+            }
+          fi
+
+          if [ "$frontend_status" = "N/A" ]; then
+            frontend_justification="$(echo "$agent_plan_block" | sed -nE 's/^- AGENT_FRONTEND_JUSTIFICATION:\s*(.+)$/\1/p' | head -n 1)"
+            [ -z "$frontend_justification" ] && {
+              echo "Agent Plan requires AGENT_FRONTEND_JUSTIFICATION when AGENT_FRONTEND_STATUS is N/A."
+              exit 1
+            }
+            echo "$frontend_justification" | grep -Eqi '^(n/a|na|none|-)$' && {
+              echo "AGENT_FRONTEND_JUSTIFICATION cannot be a placeholder value."
+              exit 1
+            }
+          fi
+
+          if [ "$qa_status" = "N/A" ]; then
+            qa_justification="$(echo "$agent_plan_block" | sed -nE 's/^- AGENT_QA_JUSTIFICATION:\s*(.+)$/\1/p' | head -n 1)"
+            [ -z "$qa_justification" ] && {
+              echo "Agent Plan requires AGENT_QA_JUSTIFICATION when AGENT_QA_STATUS is N/A."
+              exit 1
+            }
+            echo "$qa_justification" | grep -Eqi '^(n/a|na|none|-)$' && {
+              echo "AGENT_QA_JUSTIFICATION cannot be a placeholder value."
+              exit 1
+            }
+          fi
+
           records_block="$(echo "$PR_BODY" | awk '
             /^## Evidence Records/ {capture=1; next}
             /^## / && capture==1 {exit}

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ PR agent plan template (required for factory PRs):
 - AGENT_BACKEND_STATUS: PLANNED
 - AGENT_FRONTEND_STATUS: N/A
 - AGENT_QA_STATUS: PLANNED
+- AGENT_FRONTEND_JUSTIFICATION: repository has no frontend tree in pilot scope
 ```
 
 When `factory` PR checks run, these values drive the execution of CI jobs: `agent_backend`, `agent_frontend`, and `agent_qa`.
+If any agent status is `N/A`, include the corresponding `AGENT_<NAME>_JUSTIFICATION` with a non-placeholder reason.
 
 PR evidence records template (required for factory PRs):
 


### PR DESCRIPTION
## Changes
- Adds conditional contract rule: whenever an agent status is `N/A`, a corresponding non-placeholder justification is required.
- New conditional justification checks:
  - `AGENT_BACKEND_JUSTIFICATION` when backend status is `N/A`
  - `AGENT_FRONTEND_JUSTIFICATION` when frontend status is `N/A`
  - `AGENT_QA_JUSTIFICATION` when QA status is `N/A`
- Placeholder justifications are rejected (`n/a`, `na`, `none`, `-`).
- README Agent Plan template updated with `AGENT_FRONTEND_JUSTIFICATION` example.
- Closes #47.

## Tests
- `scripts/quality/run_quality_security_checks.sh`
- `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`

## Acceptance Criteria
- [x] `N/A` statuses require explicit non-placeholder justification.
- [x] Validation applies per agent dimension (backend/frontend/qa).
- [x] README documents conditional justification pattern.

## Risks
- Existing PR templates with `N/A` but no justification will fail until adjusted.
- Justification quality is minimally syntactic (content depth not yet scored).

## Risk Matrix
- Risk: initial non-compliance for teams adopting updated contract
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: template updated with explicit example and required fields.
- Risk: low-quality but non-placeholder justifications
  - Impact: Medium
  - Likelihood: Low
  - Mitigation: future iteration can add minimum length/semantic checks.

## Traceability
- Issue URL: https://github.com/reinaldosaraiva/factory-workflow-eval/issues/47
- PR URL: https://github.com/reinaldosaraiva/factory-workflow-eval/pull/48
- Run URL: https://github.com/reinaldosaraiva/factory-workflow-eval/actions/runs/22408530404

## Agent Plan
- AGENT_BACKEND_STATUS: PLANNED
- AGENT_FRONTEND_STATUS: N/A
- AGENT_FRONTEND_JUSTIFICATION: pilot repository has no frontend source tree
- AGENT_QA_STATUS: PLANNED

## Execution Evidence
- Command: `scripts/quality/run_quality_security_checks.sh`
- Result: `PASS (all checks passed)`
- Command: `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`
- Result: `PASS (TOTAL 90% >= 70%)`

## Evidence Records
- EVIDENCE_SCHEMA_VERSION: v1
- EVIDENCE_COMMAND_1: scripts/quality/run_quality_security_checks.sh
- EVIDENCE_RESULT_1: PASS (all checks passed)
- EVIDENCE_ARTIFACT_1: quality/run_quality_security_checks.log
- EVIDENCE_COMMAND_2: scripts/quality/run_coverage_gate.sh 70
- EVIDENCE_RESULT_2: PASS (TOTAL 90% >= 70%)
- EVIDENCE_ARTIFACT_2: coverage/summary-total-90.txt

## Evidence
- Local quality/security baseline: PASS
- Local coverage gate: PASS (`TOTAL 90%`)
- Changed files:
  - `.github/workflows/factory-validation.yml`
  - `README.md`