### PR TITLE
ci: validar qualidade mínima das justificativas N/A

### DIFF
--- a/.github/workflows/factory-validation.yml
+++ b/.github/workflows/factory-validation.yml
@@ -141,6 +141,14 @@ jobs:
               echo "AGENT_BACKEND_JUSTIFICATION cannot be a placeholder value."
               exit 1
             }
+            [ "$(echo "$backend_justification" | tr -d '[:space:]' | wc -c | tr -d ' ')" -lt 15 ] && {
+              echo "AGENT_BACKEND_JUSTIFICATION must contain at least 15 non-space characters."
+              exit 1
+            }
+            echo "$backend_justification" | grep -Eqi '(backend|api|scope|escopo|teste|test)' || {
+              echo "AGENT_BACKEND_JUSTIFICATION must mention backend/API/scope context."
+              exit 1
+            }
           fi
 
           if [ "$frontend_status" = "N/A" ]; then
@@ -153,6 +161,14 @@ jobs:
               echo "AGENT_FRONTEND_JUSTIFICATION cannot be a placeholder value."
               exit 1
             }
+            [ "$(echo "$frontend_justification" | tr -d '[:space:]' | wc -c | tr -d ' ')" -lt 15 ] && {
+              echo "AGENT_FRONTEND_JUSTIFICATION must contain at least 15 non-space characters."
+              exit 1
+            }
+            echo "$frontend_justification" | grep -Eqi '(frontend|web|scope|escopo|teste|test)' || {
+              echo "AGENT_FRONTEND_JUSTIFICATION must mention frontend/web/scope context."
+              exit 1
+            }
           fi
 
           if [ "$qa_status" = "N/A" ]; then
@@ -163,6 +179,14 @@ jobs:
             }
             echo "$qa_justification" | grep -Eqi '^(n/a|na|none|-)$' && {
               echo "AGENT_QA_JUSTIFICATION cannot be a placeholder value."
+              exit 1
+            }
+            [ "$(echo "$qa_justification" | tr -d '[:space:]' | wc -c | tr -d ' ')" -lt 15 ] && {
+              echo "AGENT_QA_JUSTIFICATION must contain at least 15 non-space characters."
+              exit 1
+            }
+            echo "$qa_justification" | grep -Eqi '(qa|quality|teste|test|scope|escopo)' || {
+              echo "AGENT_QA_JUSTIFICATION must mention QA/test/scope context."
               exit 1
             }
           fi

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ PR agent plan template (required for factory PRs):
 
 When `factory` PR checks run, these values drive the execution of CI jobs: `agent_backend`, `agent_frontend`, and `agent_qa`.
 If any agent status is `N/A`, include the corresponding `AGENT_<NAME>_JUSTIFICATION` with a non-placeholder reason.
+`N/A` justification must have at least 15 non-space characters and mention scope context (`backend/api`, `frontend/web`, or `qa/test`).
 
 PR evidence records template (required for factory PRs):
 


### PR DESCRIPTION
## Changes
- Adds minimum quality checks for `AGENT_*_JUSTIFICATION` when status is `N/A`.
- New quality rules for N/A justifications:
  - at least 15 non-space characters
  - must mention scope context keywords
- Existing placeholder blocking remains in place.
- README updated with quality requirements for `N/A` justifications.
- Closes #49.

## Tests
- `scripts/quality/run_quality_security_checks.sh`
- `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`

## Acceptance Criteria
- [x] `N/A` justification length minimum is enforced.
- [x] `N/A` justification must mention scope context.
- [x] Placeholder blocking continues to apply.
- [x] README reflects the rule.

## Risks
- Stricter textual checks may reject short but valid justifications.
- Keyword-based scope validation may require tuning over time.

## Risk Matrix
- Risk: false rejection of concise justifications
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: document examples and adjust threshold if needed.
- Risk: keyword list misses legitimate wording
  - Impact: Low
  - Likelihood: Medium
  - Mitigation: extend keyword list based on real failures.

## Traceability
- Issue URL: https://github.com/reinaldosaraiva/factory-workflow-eval/issues/49
- PR URL: https://github.com/reinaldosaraiva/factory-workflow-eval/pull/50
- Run URL: https://github.com/reinaldosaraiva/factory-workflow-eval/actions/runs/22409732199

## Agent Plan
- AGENT_BACKEND_STATUS: PLANNED
- AGENT_FRONTEND_STATUS: N/A
- AGENT_FRONTEND_JUSTIFICATION: frontend/web scope is out of this backend-focused pilot execution
- AGENT_QA_STATUS: PLANNED

## Execution Evidence
- Command: `scripts/quality/run_quality_security_checks.sh`
- Result: `PASS (all checks passed)`
- Command: `python3 -m venv .venv && source .venv/bin/activate && python -m pip install --disable-pip-version-check coverage && scripts/quality/run_coverage_gate.sh 70`
- Result: `PASS (TOTAL 90% >= 70%)`

## Evidence Records
- EVIDENCE_SCHEMA_VERSION: v1
- EVIDENCE_COMMAND_1: scripts/quality/run_quality_security_checks.sh
- EVIDENCE_RESULT_1: PASS (all checks passed)
- EVIDENCE_ARTIFACT_1: quality/run_quality_security_checks.log
- EVIDENCE_COMMAND_2: scripts/quality/run_coverage_gate.sh 70
- EVIDENCE_RESULT_2: PASS (TOTAL 90% >= 70%)
- EVIDENCE_ARTIFACT_2: coverage/summary-total-90.txt

## Evidence
- Local quality/security baseline: PASS
- Local coverage gate: PASS (`TOTAL 90%`)
- Changed files:
  - `.github/workflows/factory-validation.yml`
  - `README.md`